### PR TITLE
Override Github indentation settings (again)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*.c]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.h]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
Add `.editorconfig` in order to improve indentation as viewed in Github editor.