### PR TITLE
Level format compatibility with cokoban

### DIFF
--- a/sokoban.c
+++ b/sokoban.c
@@ -226,11 +226,11 @@ uint8_t mapLoad( const char *fname)
 					t = TILE_WALL;
 					break;
 
-			case '&':
+			case '.':
 					t = TILE_SOCKET;
 					break;
 
-			case '#':
+			case '&':
 					t = TILE_BOX;
 					break;
 


### PR DESCRIPTION
In order to have full level compatibility with `cokoban`, `mapLoad` tile associations had to be changed. They don't affect the game itself, apart from the level file format.

Old level format vs. `cokoban` level format:

|Tile|Sokoban|Cokoban|
|:---:|:---:|:---:|
|`TILE_AIR`|` `|` `|
|`TILE_PLAYER`|`@`|`@`|
|`TILE_BOX`|`#`|`&`|
|`TILE_SOCKET`|`&`|`.`|
|`TILE_SOCKETPLAYER`|`P`|`P`|
|`TILE_SOCKETBOX`|`B`|`B`|

Also, additional feature such as ignoring lines beginning with e.g.  `~` by `mapLoad` function should be taken into consideration. Such enhancement would enable game and level creators to store some information in the level files, such as level name, level creator, best score, etc., which could be a major improvement made to the game.